### PR TITLE
fix: MongoRepository.GetAllAsync().

### DIFF
--- a/src/Liquid.Repository.EntityFramework/EntityFrameworkRepository.cs
+++ b/src/Liquid.Repository.EntityFramework/EntityFrameworkRepository.cs
@@ -53,7 +53,7 @@ namespace Liquid.Repository.EntityFramework
         }
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
         ///<inheritdoc/>
-        public async Task<IEnumerable<TEntity>> GetAllAsync()
+        public async Task<IEnumerable<TEntity>> FindAllAsync()
         {
             IEnumerable<TEntity> returnValue = _queryableReadOnly;
 

--- a/src/Liquid.Repository.EntityFramework/Liquid.Repository.EntityFramework.csproj
+++ b/src/Liquid.Repository.EntityFramework/Liquid.Repository.EntityFramework.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <PackageId>Liquid.Repository.EntityFramework</PackageId>
-    <Version>2.0.0-preview-20210712-03</Version>
+    <Version>2.0.0-preview-20210712-04</Version>
     <Authors>Avanade Brazil</Authors>
     <Company>Avanade Inc.</Company>
     <Product>Liquid - Modern Application Framework</Product>

--- a/src/Liquid.Repository.Mongo/Liquid.Repository.Mongo.csproj
+++ b/src/Liquid.Repository.Mongo/Liquid.Repository.Mongo.csproj
@@ -10,7 +10,7 @@
     <Copyright>Avanade 2019</Copyright>
     <PackageProjectUrl>https://github.com/Avanade/Liquid.Repository</PackageProjectUrl>
     <PackageIcon>logo.png</PackageIcon>
-    <Version>2.0.0-preview-20210712-04</Version>
+    <Version>2.0.0-preview-20210712-05</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
     <DebugType>Full</DebugType>

--- a/src/Liquid.Repository.Mongo/MongoRepository.cs
+++ b/src/Liquid.Repository.Mongo/MongoRepository.cs
@@ -65,10 +65,10 @@ namespace Liquid.Repository.Mongo
         }
 
         ///<inheritdoc/>
-        public async Task<IEnumerable<TEntity>> GetAllAsync()
+        public async Task<IEnumerable<TEntity>> FindAllAsync()
         {
             var collection = MongoDataContext.Database.GetCollection<TEntity>(_settings.CollectionName);
-            var returnValue = (await collection.FindAsync(new BsonDocument(), MongoDataContext?.ClientSessionHandle)).Current.AsEnumerable();
+            var returnValue = (await collection.FindAsync(_ => true, MongoDataContext?.ClientSessionHandle)).Current.AsEnumerable();
 
             return returnValue;
         }

--- a/src/Liquid.Repository/ILiquidRepository.cs
+++ b/src/Liquid.Repository/ILiquidRepository.cs
@@ -60,6 +60,6 @@ namespace Liquid.Repository
         /// Retrieve all entities.
         /// </summary>
         /// <returns>List of all entities.</returns>
-        Task<IEnumerable<TEntity>> GetAllAsync();
+        Task<IEnumerable<TEntity>> FindAllAsync();
     }
 }

--- a/src/Liquid.Repository/Liquid.Repository.csproj
+++ b/src/Liquid.Repository/Liquid.Repository.csproj
@@ -10,7 +10,7 @@
     <Copyright>Avanade 2019</Copyright>
     <PackageProjectUrl>https://github.com/Avanade/Liquid.Repository</PackageProjectUrl>
     <PackageIcon>logo.png</PackageIcon>
-    <Version>2.0.0-preview-20210712-03</Version>
+    <Version>2.0.0-preview-20210712-04</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
     <DebugType>Full</DebugType>

--- a/test/Liquid.Repository.EntityFramework.Tests/EntityFrameworkRepositoryTest.cs
+++ b/test/Liquid.Repository.EntityFramework.Tests/EntityFrameworkRepositoryTest.cs
@@ -152,7 +152,7 @@ namespace Liquid.Repository.EntityFramework.Tests
             var mockRepository = GenerateMockRepository();
 
             //Act
-            var result = await mockRepository.GetAllAsync();
+            var result = await mockRepository.FindAllAsync();
 
             //Assert
             Assert.NotNull(result);
@@ -170,7 +170,7 @@ namespace Liquid.Repository.EntityFramework.Tests
             var mockRepository = GenerateMockRepository(dbSet);
 
             //Act
-            var result = await mockRepository.GetAllAsync();
+            var result = await mockRepository.FindAllAsync();
 
             //Assert
             Assert.IsEmpty(result);

--- a/test/Liquid.Repository.Mongo.Tests/MongoRepositoryTests.cs
+++ b/test/Liquid.Repository.Mongo.Tests/MongoRepositoryTests.cs
@@ -94,7 +94,7 @@ namespace Liquid.Repository.Mongo.Tests
         [Test]
         public async Task GetAllAsync_WhenCollectionExists_ReturnItens()
         {
-            var result = await _sut.GetAllAsync();
+            var result = await _sut.FindAllAsync();
 
             _dbDataContext.Database.Received(1).GetCollection<TestEntity>("TestEntities");
 
@@ -108,7 +108,7 @@ namespace Liquid.Repository.Mongo.Tests
         {
             _dbDataContext.Database.When(o => o.GetCollection<TestEntity>(Arg.Any<string>())).Do((call) => throw new Exception());
 
-            var test = _sut.GetAllAsync();
+            var test = _sut.FindAllAsync();
 
             Assert.ThrowsAsync<Exception>(() => test);
         }


### PR DESCRIPTION
fix: MongoRepository.GetAllAsync(). Include change method name from GetAllAsync() to FindAllAsync() in all implementations em interfaces.