### PR TITLE
Replacing project references by Nuget package dependencies

### DIFF
--- a/src/Liquid.Repository.EntityFramework/Liquid.Repository.EntityFramework.csproj
+++ b/src/Liquid.Repository.EntityFramework/Liquid.Repository.EntityFramework.csproj
@@ -18,12 +18,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Liquid.Repository" Version="2.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.11" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.11" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\Liquid.Repository\Liquid.Repository.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Liquid.Repository.Mongo/Liquid.Repository.Mongo.csproj
+++ b/src/Liquid.Repository.Mongo/Liquid.Repository.Mongo.csproj
@@ -25,13 +25,10 @@
   
 
   <ItemGroup>
+    <PackageReference Include="Liquid.Repository" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="5.0.0" />
     <PackageReference Include="MongoDB.Driver" Version="2.13.2" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\Liquid.Repository\Liquid.Repository.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Doing this should increase code coverage analysis on cartridge projects and increase the independency of them.